### PR TITLE
Impersonate: bugfix `chrome_123`, `chrome_124` headers

### DIFF
--- a/src/impersonate/profile/chrome/v123.rs
+++ b/src/impersonate/profile/chrome/v123.rs
@@ -2,10 +2,7 @@ use boring::ssl::{
     CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
 };
 use http::{
-    header::{
-        ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, DNT, UPGRADE_INSECURE_REQUESTS,
-        USER_AGENT,
-    },
+    header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
 use std::sync::Arc;
@@ -95,7 +92,6 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {
-    headers.insert(CACHE_CONTROL, HeaderValue::from_static("max-age=0"));
     headers.insert(
         "sec-ch-ua",
         HeaderValue::from_static(
@@ -104,22 +100,18 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     );
     headers.insert("sec-ch-ua-mobile", HeaderValue::from_static("?0"));
     headers.insert("sec-ch-ua-platform", HeaderValue::from_static("\"macOS\""));
-    headers.insert(DNT, HeaderValue::from_static("1"));
     headers.insert(UPGRADE_INSECURE_REQUESTS, HeaderValue::from_static("1"));
     headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"));
     headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
-    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+    headers.insert("Sec-Fetch-Site", HeaderValue::from_static("?1"));
+    headers.insert("Sec-Fetch-Mode", HeaderValue::from_static("same-site"));
+    headers.insert("Sec-Fetch-User", HeaderValue::from_static("document"));
+    headers.insert("Sec-Fetch-Dest", HeaderValue::from_static("navigate"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br, zstd"),
     );
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en;q=0.8,en-GB;q=0.7,en-US;q=0.6"),
-    );
+    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US;q=1.0"));
 
     headers
 }

--- a/src/impersonate/profile/chrome/v124.rs
+++ b/src/impersonate/profile/chrome/v124.rs
@@ -2,10 +2,7 @@ use boring::ssl::{
     CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion,
 };
 use http::{
-    header::{
-        ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, DNT, UPGRADE_INSECURE_REQUESTS,
-        USER_AGENT,
-    },
+    header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
 };
 use std::sync::Arc;
@@ -104,7 +101,6 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {
-    headers.insert(CACHE_CONTROL, HeaderValue::from_static("max-age=0"));
     headers.insert(
         "sec-ch-ua",
         HeaderValue::from_static(
@@ -113,22 +109,18 @@ fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     );
     headers.insert("sec-ch-ua-mobile", HeaderValue::from_static("?0"));
     headers.insert("sec-ch-ua-platform", HeaderValue::from_static("\"macOS\""));
-    headers.insert(DNT, HeaderValue::from_static("1"));
     headers.insert(UPGRADE_INSECURE_REQUESTS, HeaderValue::from_static("1"));
     headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"));
     headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
-    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-    headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+    headers.insert("Sec-Fetch-Site", HeaderValue::from_static("?1"));
+    headers.insert("Sec-Fetch-Mode", HeaderValue::from_static("same-site"));
+    headers.insert("Sec-Fetch-User", HeaderValue::from_static("document"));
+    headers.insert("Sec-Fetch-Dest", HeaderValue::from_static("navigate"));
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br, zstd"),
     );
-    headers.insert(
-        ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en;q=0.8,en-GB;q=0.7,en-US;q=0.6"),
-    );
+    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US;q=1.0"));
 
     headers
 }


### PR DESCRIPTION
### Reason
Library's requests are defined as bot activities.

### Source
https://github.com/apify/fingerprint-suite
https://github.com/daijro/browserforge

### Get headers
`pip install browserforge`
<details>
<summary>headers.py</summary>

```python3
import json
from collections import Counter
from browserforge.headers import HeaderGenerator
from browserforge.headers import Browser

browsers = [
    Browser(name='chrome', min_version=124, max_version=124),
]
headers = HeaderGenerator(browser=browsers, os='macos')

def get_header():
    return headers.generate()


def compute_probabilities(num_iterations: int = 1000):
    headers_list = []
    for _ in range(num_iterations):
        h = get_header()
        hj = json.dumps(h)
        headers_list.append(hj)

    header_counts = Counter(headers_list)
    # Calculate probabilities
    total_headers = len(headers_list)
    probabilities = {header: count / total_headers for header, count in header_counts.items()}
    
    # Return headers with their probabilities
    results = [{'header': json.loads(header), 'probability': probability} for header, probability in probabilities.items()]
    return sorted(results, key=lambda x: x["probability"], reverse=True)[:14]

# Example usage
probabilities = compute_probabilities()
for header in probabilities:
    print(header)
```
</details>

### Headers
```python3
{'sec-ch-ua': '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"', 'sec-ch-ua-mobile': '?0', 'sec-ch-ua-platform': '"macOS"', 'Upgrade-Insecure-Requests': '1', 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36', 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7', 'Sec-Fetch-Site': '?1', 'Sec-Fetch-Mode': 'same-site', 'Sec-Fetch-User': 'document', 'Sec-Fetch-Dest': 'navigate', 'Accept-Encoding': 'gzip, deflate, br, zstd', 'Accept-Language': 'en-US;q=1.0'}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced header management for better compatibility and performance.
  - Updated language preferences to improve localization and user experience.

- **Bug Fixes**
  - Corrected inconsistencies in header naming for improved web interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->