### PR TITLE
impersonate: add `chrome_126`

### DIFF
--- a/src/impersonate/profile/chrome/mod.rs
+++ b/src/impersonate/profile/chrome/mod.rs
@@ -14,4 +14,5 @@ pub mod v119;
 pub mod v120;
 pub mod v123;
 pub mod v124;
+pub mod v126;
 pub mod v99;

--- a/src/impersonate/profile/chrome/v126.rs
+++ b/src/impersonate/profile/chrome/v126.rs
@@ -1,0 +1,126 @@
+use boring::ssl::{
+    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion,
+};
+use http::{
+    header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
+    HeaderMap, HeaderValue,
+};
+use std::sync::Arc;
+
+use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
+    ImpersonateSettings {
+        tls_builder_func: Arc::new(create_ssl_connector),
+        http2: Http2Data {
+            initial_stream_window_size: Some(6291456),
+            initial_connection_window_size: Some(15728640),
+            max_concurrent_streams: None,
+            max_header_list_size: Some(262144),
+            header_table_size: Some(65536),
+            enable_push: Some(false),
+        },
+        headers: create_headers(headers),
+        gzip: true,
+        brotli: true,
+    }
+}
+
+fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
+    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
+
+    builder.set_default_verify_paths().unwrap();
+
+    builder.set_grease_enabled(true);
+
+    builder.enable_ocsp_stapling();
+
+    let cipher_list = [
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+    ];
+
+    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
+
+    let sigalgs_list = [
+        "ecdsa_secp256r1_sha256",
+        "rsa_pss_rsae_sha256",
+        "rsa_pkcs1_sha256",
+        "ecdsa_secp384r1_sha384",
+        "rsa_pss_rsae_sha384",
+        "rsa_pkcs1_sha384",
+        "rsa_pss_rsae_sha512",
+        "rsa_pkcs1_sha512",
+    ];
+
+    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+
+    builder
+        .set_curves(&[
+            SslCurve::X25519_KYBER768_DRAFT00,
+            SslCurve::X25519,
+            SslCurve::SECP256R1,
+            SslCurve::SECP384R1,
+        ])
+        .unwrap();
+
+    builder.enable_signed_cert_timestamps();
+
+    if h2 {
+        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
+    } else {
+        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
+    }
+
+    builder
+        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
+        .unwrap();
+
+    builder
+        .set_min_proto_version(Some(SslVersion::TLS1_2))
+        .unwrap();
+
+    builder
+        .set_max_proto_version(Some(SslVersion::TLS1_3))
+        .unwrap();
+
+    builder
+}
+
+fn create_headers(mut headers: HeaderMap) -> HeaderMap {
+    headers.insert(
+        "sec-ch-ua",
+        HeaderValue::from_static(
+            "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"126\", \"Google Chrome\";v=\"126\"",
+        ),
+    );
+    headers.insert("sec-ch-ua-mobile", HeaderValue::from_static("?0"));
+    headers.insert("sec-ch-ua-platform", HeaderValue::from_static("\"macOS\""));
+    headers.insert(UPGRADE_INSECURE_REQUESTS, HeaderValue::from_static("1"));
+    headers.insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"));
+    headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
+    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
+    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+    headers.insert(
+        ACCEPT_ENCODING,
+        HeaderValue::from_static("gzip, deflate, br, zstd"),
+    );
+    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
+
+    headers
+}

--- a/src/impersonate/profile/mod.rs
+++ b/src/impersonate/profile/mod.rs
@@ -66,6 +66,7 @@ fn get_config_from_ver(ver: Impersonate) -> ImpersonateSettings {
         Impersonate::Chrome120 => chrome::v120::get_settings,
         Impersonate::Chrome123 => chrome::v123::get_settings,
         Impersonate::Chrome124 => chrome::v124::get_settings,
+        Impersonate::Chrome126 => chrome::v126::get_settings,
         Impersonate::SafariIos17_2 => safari::safari_ios_17_2::get_settings,
         Impersonate::SafariIos17_4_1 => safari::safari_ios_17_4_1::get_settings,
         Impersonate::SafariIos16_5 => safari::safari_ios_16_5::get_settings,
@@ -110,6 +111,7 @@ pub enum Impersonate {
     Chrome120,
     Chrome123,
     Chrome124,
+    Chrome126,
     SafariIos17_2,
     SafariIos17_4_1,
     SafariIos16_5,
@@ -155,6 +157,7 @@ impl FromStr for Impersonate {
             "chrome_120" => Ok(Impersonate::Chrome120),
             "chrome_123" => Ok(Impersonate::Chrome123),
             "chrome_124" => Ok(Impersonate::Chrome124),
+            "chrome_126" => Ok(Impersonate::Chrome126),
             "safari_ios_17.2" => Ok(Impersonate::SafariIos17_2),
             "safari_ios_17.4.1" => Ok(Impersonate::SafariIos17_4_1),
             "safari_15.3" => Ok(Impersonate::Safari15_3),
@@ -200,7 +203,8 @@ impl Impersonate {
             | Impersonate::Chrome119
             | Impersonate::Chrome120
             | Impersonate::Chrome123
-            | Impersonate::Chrome124 => ClientProfile::Chrome,
+            | Impersonate::Chrome124
+            | Impersonate::Chrome126 => ClientProfile::Chrome,
 
             Impersonate::SafariIos17_2
             | Impersonate::SafariIos16_5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for Chrome version 126 in the impersonation settings, providing improved SSL configuration and HTTP headers for better compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->