### PR TITLE
refactor(impersonate): Reuse code

### DIFF
--- a/src/impersonate/profile/chrome/mod.rs
+++ b/src/impersonate/profile/chrome/mod.rs
@@ -1,3 +1,7 @@
+use boring::ssl::{
+    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
+};
+
 pub mod v100;
 pub mod v101;
 pub mod v104;
@@ -16,3 +20,68 @@ pub mod v123;
 pub mod v124;
 pub mod v126;
 pub mod v99;
+
+const SIGALGS_LIST: [&str; 8] = [
+    "ecdsa_secp256r1_sha256",
+    "rsa_pss_rsae_sha256",
+    "rsa_pkcs1_sha256",
+    "ecdsa_secp384r1_sha384",
+    "rsa_pss_rsae_sha384",
+    "rsa_pkcs1_sha384",
+    "rsa_pss_rsae_sha512",
+    "rsa_pkcs1_sha512",
+];
+
+const CIPHER_LIST: [&str; 15] = [
+    "TLS_AES_128_GCM_SHA256",
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_RSA_WITH_AES_256_CBC_SHA",
+];
+
+fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
+    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
+
+    builder.set_default_verify_paths().unwrap();
+
+    builder.set_grease_enabled(true);
+
+    builder.enable_ocsp_stapling();
+
+    builder.set_cipher_list(&CIPHER_LIST.join(":")).unwrap();
+
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
+
+    builder.enable_signed_cert_timestamps();
+
+    if h2 {
+        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
+    } else {
+        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
+    }
+
+    builder
+        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
+        .unwrap();
+
+    builder
+        .set_min_proto_version(Some(SslVersion::TLS1_2))
+        .unwrap();
+
+    builder
+        .set_max_proto_version(Some(SslVersion::TLS1_3))
+        .unwrap();
+
+    builder
+}

--- a/src/impersonate/profile/chrome/v100.rs
+++ b/src/impersonate/profile/chrome/v100.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -11,6 +8,8 @@ use http::{
 };
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v101.rs
+++ b/src/impersonate/profile/chrome/v101.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -11,6 +8,8 @@ use http::{
 };
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v104.rs
+++ b/src/impersonate/profile/chrome/v104.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -11,6 +8,8 @@ use http::{
 };
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v105.rs
+++ b/src/impersonate/profile/chrome/v105.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -11,6 +8,8 @@ use http::{
 };
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v106.rs
+++ b/src/impersonate/profile/chrome/v106.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
 
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -11,6 +8,8 @@ use http::{
 };
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v107.rs
+++ b/src/impersonate/profile/chrome/v107.rs
@@ -1,16 +1,14 @@
-use std::sync::Arc;
-
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
     },
     HeaderMap, HeaderValue,
 };
+use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +25,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v109.rs
+++ b/src/impersonate/profile/chrome/v109.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, DNT, UPGRADE_INSECURE_REQUESTS, USER_AGENT,
@@ -10,6 +7,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -26,70 +25,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "ECDHE-ECDSA-AES128-GCM-SHA256",
-        "ECDHE-RSA-AES128-GCM-SHA256",
-        "ECDHE-ECDSA-AES256-GCM-SHA384",
-        "ECDHE-RSA-AES256-GCM-SHA384",
-        "ECDHE-ECDSA-CHACHA20-POLY1305",
-        "ECDHE-RSA-CHACHA20-POLY1305",
-        "ECDHE-RSA-AES128-SHA",
-        "ECDHE-RSA-AES256-SHA",
-        "AES128-GCM-SHA256",
-        "AES256-GCM-SHA384",
-        "AES128-SHA,AES256-SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v116.rs
+++ b/src/impersonate/profile/chrome/v116.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,71 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v117.rs
+++ b/src/impersonate/profile/chrome/v117.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,71 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "ECDHE-ECDSA-AES128-GCM-SHA256",
-        "ECDHE-RSA-AES128-GCM-SHA256",
-        "ECDHE-ECDSA-AES256-GCM-SHA384",
-        "ECDHE-RSA-AES256-GCM-SHA384",
-        "ECDHE-ECDSA-CHACHA20-POLY1305",
-        "ECDHE-RSA-CHACHA20-POLY1305",
-        "ECDHE-RSA-AES128-SHA",
-        "ECDHE-RSA-AES256-SHA",
-        "AES128-GCM-SHA256",
-        "AES256-GCM-SHA384",
-        "AES128-SHA",
-        "AES256-SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v119.rs
+++ b/src/impersonate/profile/chrome/v119.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, DNT, UPGRADE_INSECURE_REQUESTS,
@@ -11,6 +8,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v120.rs
+++ b/src/impersonate/profile/chrome/v120.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{
         ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, CACHE_CONTROL, DNT, UPGRADE_INSECURE_REQUESTS,
@@ -11,6 +8,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -27,71 +26,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v123.rs
+++ b/src/impersonate/profile/chrome/v123.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -25,72 +24,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         brotli: true,
     }
 }
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
-}
-
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {
     headers.insert(
         "sec-ch-ua",

--- a/src/impersonate/profile/chrome/v124.rs
+++ b/src/impersonate/profile/chrome/v124.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,80 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519_KYBER768_DRAFT00,
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/chrome/v126.rs
+++ b/src/impersonate/profile/chrome/v126.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslCurve, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,80 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder
-        .set_curves(&[
-            SslCurve::X25519_KYBER768_DRAFT00,
-            SslCurve::X25519,
-            SslCurve::SECP256R1,
-            SslCurve::SECP384R1,
-        ])
-        .unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/edge/edge101.rs
+++ b/src/impersonate/profile/edge/edge101.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,71 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/edge/edge122.rs
+++ b/src/impersonate/profile/edge/edge122.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,71 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/edge/edge99.rs
+++ b/src/impersonate/profile/edge/edge99.rs
@@ -1,6 +1,3 @@
-use boring::ssl::{
-    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
-};
 use http::{
     header::{ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, UPGRADE_INSECURE_REQUESTS, USER_AGENT},
     HeaderMap, HeaderValue,
@@ -8,6 +5,8 @@ use http::{
 use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
+
+use super::create_ssl_connector;
 
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
@@ -24,71 +23,6 @@ pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
         gzip: true,
         brotli: true,
     }
-}
-
-fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
-    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
-
-    builder.set_default_verify_paths().unwrap();
-
-    builder.set_grease_enabled(true);
-
-    builder.enable_ocsp_stapling();
-
-    let cipher_list = [
-        "TLS_AES_128_GCM_SHA256",
-        "TLS_AES_256_GCM_SHA384",
-        "TLS_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_RSA_WITH_AES_128_CBC_SHA",
-        "TLS_RSA_WITH_AES_256_CBC_SHA",
-    ];
-
-    builder.set_cipher_list(&cipher_list.join(":")).unwrap();
-
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
-
-    builder.enable_signed_cert_timestamps();
-
-    if h2 {
-        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
-    } else {
-        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
-    }
-
-    builder
-        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
-        .unwrap();
-
-    builder
-        .set_min_proto_version(Some(SslVersion::TLS1_2))
-        .unwrap();
-
-    builder
-        .set_max_proto_version(Some(SslVersion::TLS1_3))
-        .unwrap();
-
-    builder
 }
 
 fn create_headers(mut headers: HeaderMap) -> HeaderMap {

--- a/src/impersonate/profile/edge/mod.rs
+++ b/src/impersonate/profile/edge/mod.rs
@@ -1,3 +1,72 @@
+use boring::ssl::{
+    CertCompressionAlgorithm, SslConnector, SslConnectorBuilder, SslMethod, SslVersion,
+};
+
 pub mod edge101;
 pub mod edge122;
 pub mod edge99;
+
+const SIGALGS_LIST: [&str; 8] = [
+    "ecdsa_secp256r1_sha256",
+    "rsa_pss_rsae_sha256",
+    "rsa_pkcs1_sha256",
+    "ecdsa_secp384r1_sha384",
+    "rsa_pss_rsae_sha384",
+    "rsa_pkcs1_sha384",
+    "rsa_pss_rsae_sha512",
+    "rsa_pkcs1_sha512",
+];
+
+const CIPHER_LIST: [&str; 15] = [
+    "TLS_AES_128_GCM_SHA256",
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_CBC_SHA",
+    "TLS_RSA_WITH_AES_256_CBC_SHA",
+];
+
+fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
+    let mut builder = SslConnector::builder(SslMethod::tls_client()).unwrap();
+
+    builder.set_default_verify_paths().unwrap();
+
+    builder.set_grease_enabled(true);
+
+    builder.enable_ocsp_stapling();
+
+    builder.set_cipher_list(&CIPHER_LIST.join(":")).unwrap();
+
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
+
+    builder.enable_signed_cert_timestamps();
+
+    if h2 {
+        builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();
+    } else {
+        builder.set_alpn_protos(b"\x08http/1.1").unwrap();
+    }
+
+    builder
+        .add_cert_compression_alg(CertCompressionAlgorithm::Brotli)
+        .unwrap();
+
+    builder
+        .set_min_proto_version(Some(SslVersion::TLS1_2))
+        .unwrap();
+
+    builder
+        .set_max_proto_version(Some(SslVersion::TLS1_3))
+        .unwrap();
+
+    builder
+}

--- a/src/impersonate/profile/okhttp/mod.rs
+++ b/src/impersonate/profile/okhttp/mod.rs
@@ -5,3 +5,15 @@ pub mod okhttp3_9;
 pub mod okhttp4_10;
 pub mod okhttp4_9;
 pub mod okhttp5;
+
+const SIGALGS_LIST: [&str; 9] = [
+    "ecdsa_secp256r1_sha256",
+    "rsa_pss_rsae_sha256",
+    "rsa_pkcs1_sha256",
+    "ecdsa_secp384r1_sha384",
+    "rsa_pss_rsae_sha384",
+    "rsa_pkcs1_sha384",
+    "rsa_pss_rsae_sha512",
+    "rsa_pkcs1_sha512",
+    "rsa_pkcs1_sha1",
+];

--- a/src/impersonate/profile/okhttp/okhttp3_11.rs
+++ b/src/impersonate/profile/okhttp/okhttp3_11.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -53,19 +55,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/okhttp/okhttp3_13.rs
+++ b/src/impersonate/profile/okhttp/okhttp3_13.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -58,19 +60,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/okhttp/okhttp3_14.rs
+++ b/src/impersonate/profile/okhttp/okhttp3_14.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(|h2| create_ssl_connector(h2)),
@@ -56,19 +58,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/okhttp/okhttp3_9.rs
+++ b/src/impersonate/profile/okhttp/okhttp3_9.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -55,19 +57,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/okhttp/okhttp4_10.rs
+++ b/src/impersonate/profile/okhttp/okhttp4_10.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -56,19 +58,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/okhttp/okhttp4_9.rs
+++ b/src/impersonate/profile/okhttp/okhttp4_9.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -55,19 +57,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/okhttp/okhttp5.rs
+++ b/src/impersonate/profile/okhttp/okhttp5.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -56,19 +58,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     if h2 {
         builder.set_alpn_protos(b"\x02h2\x08http/1.1").unwrap();

--- a/src/impersonate/profile/safari/mod.rs
+++ b/src/impersonate/profile/safari/mod.rs
@@ -8,3 +8,17 @@ pub mod safari17_4_1;
 pub mod safari_ios_16_5;
 pub mod safari_ios_17_2;
 pub mod safari_ios_17_4_1;
+
+const SIGALGS_LIST: [&str; 11] = [
+    "ecdsa_secp256r1_sha256",
+    "rsa_pss_rsae_sha256",
+    "rsa_pkcs1_sha256",
+    "ecdsa_secp384r1_sha384",
+    "ecdsa_sha1",
+    "rsa_pss_rsae_sha384",
+    "rsa_pss_rsae_sha384",
+    "rsa_pkcs1_sha384",
+    "rsa_pss_rsae_sha512",
+    "rsa_pkcs1_sha512",
+    "rsa_pkcs1_sha1",
+];

--- a/src/impersonate/profile/safari/safari15_3.rs
+++ b/src/impersonate/profile/safari/safari15_3.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -66,21 +68,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari15_5.rs
+++ b/src/impersonate/profile/safari/safari15_5.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari15_6_1.rs
+++ b/src/impersonate/profile/safari/safari15_6_1.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari16.rs
+++ b/src/impersonate/profile/safari/safari16.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari16_5.rs
+++ b/src/impersonate/profile/safari/safari16_5.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari17_2_1.rs
+++ b/src/impersonate/profile/safari/safari17_2_1.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari17_4_1.rs
+++ b/src/impersonate/profile/safari/safari17_4_1.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari_ios_16_5.rs
+++ b/src/impersonate/profile/safari/safari_ios_16_5.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari_ios_17_2.rs
+++ b/src/impersonate/profile/safari/safari_ios_17_2.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[

--- a/src/impersonate/profile/safari/safari_ios_17_4_1.rs
+++ b/src/impersonate/profile/safari/safari_ios_17_4_1.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use crate::impersonate::{Http2Data, ImpersonateSettings};
 
+use super::SIGALGS_LIST;
+
 pub(crate) fn get_settings(headers: HeaderMap) -> ImpersonateSettings {
     ImpersonateSettings {
         tls_builder_func: Arc::new(create_ssl_connector),
@@ -63,21 +65,7 @@ fn create_ssl_connector(h2: bool) -> SslConnectorBuilder {
 
     builder.set_cipher_list(&cipher_list.join(":")).unwrap();
 
-    let sigalgs_list = [
-        "ecdsa_secp256r1_sha256",
-        "rsa_pss_rsae_sha256",
-        "rsa_pkcs1_sha256",
-        "ecdsa_secp384r1_sha384",
-        "ecdsa_sha1",
-        "rsa_pss_rsae_sha384",
-        "rsa_pss_rsae_sha384",
-        "rsa_pkcs1_sha384",
-        "rsa_pss_rsae_sha512",
-        "rsa_pkcs1_sha512",
-        "rsa_pkcs1_sha1",
-    ];
-
-    builder.set_sigalgs_list(&sigalgs_list.join(":")).unwrap();
+    builder.set_sigalgs_list(&SIGALGS_LIST.join(":")).unwrap();
 
     builder
         .set_curves(&[


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced hardcoded lists of signature algorithms across various Safari and OkHttp profiles with a centralized constant `SIGALGS_LIST`. This improves maintainability and consistency in setting signature algorithms for SSL connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->